### PR TITLE
file.path() more robust than paste()

### DIFF
--- a/Rpkg/R/ISRaD.extra.geospatial.R
+++ b/Rpkg/R/ISRaD.extra.geospatial.R
@@ -71,7 +71,7 @@ ISRaD.extra.geospatial <- function(database,
   df.sp <- as.data.frame(lapply(df.sp, as.character), stringsAsFactors=FALSE)
   list.list <- lapply(seq_len(nrow(df.sp)), function(x) {
     x <- paste(unlist(as.character(df.sp[x,])), collapse="_")
-    x <- paste0(geodata_directory, "/", x)
+    x <- file.path(geodata_directory, x)
     return(x)
   })
   filez2 <- unlist(list.list)

--- a/Rpkg/R/ISRaD.getdata.R
+++ b/Rpkg/R/ISRaD.getdata.R
@@ -26,31 +26,31 @@ ISRaD.getdata<-function(directory, dataset = "full", extra = F, force_download =
   if (!"ISRaD_database_files" %in% list.files(directory)){
     message("\n ISRaD_database_files not found...")
     message("\n Downloading database files from: ",dataURL,"\n")
-    utils::download.file(dataURL,normalizePath(winslash="\\", paste0(directory, "/ISRaD_database_files.zip")))
-    message("\n Unzipping database files to",normalizePath(winslash="\\", paste0(directory, "/ISRaD_database_files")),"...\n")
-    utils::unzip(normalizePath(winslash="\\",paste0(directory, "/ISRaD_database_files.zip")), exdir = normalizePath(winslash="\\", paste0(directory, "/ISRaD_database_files")))
+    utils::download.file(dataURL,normalizePath(winslash="\\", file.path(directory, "ISRaD_database_files.zip")))
+    message("\n Unzipping database files to",normalizePath(winslash="\\", file.path(directory, "ISRaD_database_files")),"...\n")
+    utils::unzip(normalizePath(winslash="\\",file.path(directory, "ISRaD_database_files.zip")), exdir = normalizePath(winslash="\\", file.path(directory, "ISRaD_database_files")))
   }
 
   if (force_download){
     message("\n Replacing ISRaD_database_files ...")
     message("\n Downloading database files from: ",dataURL,"\n")
-    utils::download.file(dataURL,normalizePath(winslash="\\", paste0(directory, "/ISRaD_database_files.zip")))
+    utils::download.file(dataURL,normalizePath(winslash="\\", file.path(directory, "ISRaD_database_files.zip")))
 
-    message("\n Removing old database files in ",normalizePath(winslash="\\", paste0(directory, "/ISRaD_database_files")),"...\n")
+    message("\n Removing old database files in ",normalizePath(winslash="\\", file.path(directory, "ISRaD_database_files")),"...\n")
     reviewed<-utils::menu(c("Yes", "No"), title="Are you sure you want to replace these with the newest version? You can copy them to a new directory now if you want keep them.")
     print(reviewed)
     if (reviewed == 1){
-      for(f in list.files(normalizePath(winslash="\\", paste0(directory, "/ISRaD_database_files")), full.names=TRUE)){
+      for(f in list.files(normalizePath(winslash="\\", file.path(directory, "ISRaD_database_files")), full.names=TRUE)){
         file.remove(f)
       }
     }else {stop("Ok, keeping the old files. You can run again without force_download=T to load.")}
 
-    message("\n Unzipping database files to ",normalizePath(winslash="\\", paste0(directory, "/ISRaD_database_files")),"...\n")
-    utils::unzip(normalizePath(winslash="\\", paste0(directory, "/ISRaD_database_files.zip")), exdir = normalizePath(winslash="\\",paste0(directory, "/ISRaD_database_files")))
+    message("\n Unzipping database files to ",normalizePath(winslash="\\", file.path(directory, "ISRaD_database_files")),"...\n")
+    utils::unzip(normalizePath(winslash="\\", file.path(directory, "ISRaD_database_files.zip")), exdir = normalizePath(winslash="\\",file.path(directory, "ISRaD_database_files")))
   }
 
 
-database_files<-list.files(normalizePath(winslash="\\",paste0(directory, "/ISRaD_database_files")), full.names = TRUE)
+database_files<-list.files(normalizePath(winslash="\\",file.path(directory, "ISRaD_database_files")), full.names = TRUE)
 
 if(extra) {data_type<-"ISRaD_extra_"
   } else {data_type<-"ISRaD_data_"}

--- a/Rpkg/R/ISRaD.save.xlsx.R
+++ b/Rpkg/R/ISRaD.save.xlsx.R
@@ -14,7 +14,7 @@
 #' database <- ISRaD::Gaudinski_2001
 #' ISRaD.save.xlsx(database = database,
 #'  template_file = system.file("extdata", "ISRaD_Master_Template.xlsx", package = "ISRaD"),
-#'  outfile = paste0(tempdir(),"/Gaudinski_2001.xlsx"))
+#'  outfile = file.path(tempdir(),"Gaudinski_2001.xlsx"))
 #' }
 
 ISRaD.save.xlsx <- function(database,

--- a/Rpkg/R/QAQC.R
+++ b/Rpkg/R/QAQC.R
@@ -22,9 +22,9 @@
 #' # Save as .xlsx file
 #' ISRaD.save.xlsx(database = database,
 #'  template_file = system.file("extdata", "ISRaD_Master_Template.xlsx", package = "ISRaD"),
-#'  outfile = paste0(tempdir(),"/Gaudinski_2001.xlsx"))
+#'  outfile = file.path(tempdir(),"Gaudinski_2001.xlsx"))
 #' # Run QAQC
-#' QAQC(paste0(tempdir(),"/Gaudinski_2001.xlsx"))
+#' QAQC(file.path(tempdir(),"Gaudinski_2001.xlsx"))
 #' }
 
 QAQC <- function(file, writeQCreport=FALSE, outfile_QAQC="", summaryStats=TRUE, dataReport=FALSE, checkdoi=TRUE, verbose=TRUE){
@@ -46,7 +46,7 @@ QAQC <- function(file, writeQCreport=FALSE, outfile_QAQC="", summaryStats=TRUE, 
 
   if (writeQCreport){
     if (outfile_QAQC==""){
-      outfile_QAQC<-paste0(dirname(file), "/QAQC/QAQC_", gsub("\\.xlsx", ".txt", basename(file)))
+      outfile_QAQC<-file.path(dirname(file), "QAQC", "QAQC_", gsub("\\.xlsx", ".txt", basename(file)))
     }
   }
 

--- a/Rpkg/R/compile.R
+++ b/Rpkg/R/compile.R
@@ -26,7 +26,7 @@
 #' # Save as .xlsx file
 #' ISRaD.save.xlsx(database = database,
 #'  template_file = system.file("extdata", "ISRaD_Master_Template.xlsx", package = "ISRaD"),
-#'  outfile = paste0(tempdir(),"/Gaudinski_2001.xlsx"))
+#'  outfile = file.path(tempdir(), "Gaudinski_2001.xlsx"))
 #' # Compile .xlsx file/s in dataset_directory into ISRaD database object
 #' ISRaD.compiled <- compile(tempdir(), write_report = TRUE, write_out = TRUE,
 #'                           return_type = 'list', checkdoi = FALSE, verbose = TRUE)


### PR DESCRIPTION
R's `file.path()` is a much more platform-robust way to construct pathnames than using `paste()`.